### PR TITLE
Tiny refactor

### DIFF
--- a/GroveColorSensor.cpp
+++ b/GroveColorSensor.cpp
@@ -88,9 +88,7 @@ void GroveColorSensor::readRGB()
 	Wire.write(REG_BLOCK_READ);
 	Wire.endTransmission();
 	
-	Wire.beginTransmission(sensorAddress_);
 	Wire.requestFrom(sensorAddress_, 8);
-	delay(100);
 	
 	// if two bytes were received
 	if(8 <= Wire.available())
@@ -114,7 +112,7 @@ void GroveColorSensor::readRGB()
 	Serial.print(", ");
 	Serial.print(blue_,DEC);
 	Serial.println(" )");
-	Serial.print("The Clear channel value are: ");
+	Serial.print("The Clear channel value is: ");
 	Serial.println(clear_,DEC);
 }
 
@@ -124,9 +122,7 @@ void GroveColorSensor::readRGB(int *red, int *green, int *blue)
 	Wire.write(REG_BLOCK_READ);
 	Wire.endTransmission();
 	
-	Wire.beginTransmission(sensorAddress_);
 	Wire.requestFrom(sensorAddress_, 8);
-	delay(100);
 
 	// if two bytes were received
 	if(8 <= Wire.available())

--- a/Registers.h
+++ b/Registers.h
@@ -55,7 +55,7 @@
 #define GAIN_1 0x00
 #define GAIN_4 0x10
 #define GAIN_16 0x20
-#define GANI_64 0x30
+#define GAIN_64 0x30
 #define PRESCALER_1 0x00
 #define PRESCALER_2 0x01
 #define PRESCALER_4 0x02


### PR DESCRIPTION
Hi @KillingJacky, this refactor addresses the issue raised by @Koepel on Aug 21, 2016. The extra calls to Wire.beginTransmission() in the readRGB() functions were not necessary, and the delay in there is better added at the Arduino (or whatever device) code level, so they were removed. 

This commit also fixes a small word correction on a print statement.